### PR TITLE
initialize startTime to zero

### DIFF
--- a/src/MobusRTUSlave.cpp
+++ b/src/MobusRTUSlave.cpp
@@ -64,7 +64,7 @@ void ModbusRTUSlave::begin(uint8_t id, uint32_t baud, uint8_t config) {
 void ModbusRTUSlave::poll() {
   if (_serial->available() > 0) {
     uint8_t i = 0;
-    uint32_t startTime;
+    uint32_t startTime = 0;
     do {
       if (_serial->available() > 0) {
         startTime = micros();


### PR DESCRIPTION
when compiled using the --warning all flag, startTime is flagged as being uninitialized.  By inspection and my rather simple use of the library, i can see no problems.  This pull is only to suppress the annoying warning.  Do with it as you wish.