### PR TITLE
Add logic to create new instance from Stream object.

### DIFF
--- a/src/ModbusRTUSlave.cpp
+++ b/src/ModbusRTUSlave.cpp
@@ -1,24 +1,23 @@
 #include "ModbusRTUSlave.h"
 
-ModbusRTUSlave::ModbusRTUSlave(HardwareSerial& serial, uint8_t dePin) {
-  _hardwareSerial = &serial;
+ModbusRTUSlave::ModbusRTUSlave(Stream& serial, uint8_t dePin) {
   _serial = &serial;
   _dePin = dePin;
 }
 
+ModbusRTUSlave::ModbusRTUSlave(HardwareSerial& serial, uint8_t dePin): ModbusRTUSlave((Stream&)serial, dePin) {
+  _hardwareSerial = &serial;
+}
+
 #ifdef __AVR__
-ModbusRTUSlave::ModbusRTUSlave(SoftwareSerial& serial, uint8_t dePin) {
+ModbusRTUSlave::ModbusRTUSlave(SoftwareSerial& serial, uint8_t dePin): ModbusRTUSlave((Stream&)serial, dePin) {
   _softwareSerial = &serial;
-  _serial = &serial;
-  _dePin = dePin;
 }
 #endif
 
 #ifdef HAVE_CDCSERIAL
-ModbusRTUSlave::ModbusRTUSlave(Serial_& serial, uint8_t dePin) {
+ModbusRTUSlave::ModbusRTUSlave(Serial_& serial, uint8_t dePin): ModbusRTUSlave((Stream&)serial, dePin) {
   _usbSerial = &serial;
-  _serial = &serial;
-  _dePin = dePin;
 }
 #endif
 

--- a/src/ModbusRTUSlave.h
+++ b/src/ModbusRTUSlave.h
@@ -16,6 +16,7 @@
 
 class ModbusRTUSlave {
   public:
+    ModbusRTUSlave(Stream& serial, uint8_t dePin = NO_DE_PIN);
     ModbusRTUSlave(HardwareSerial& serial, uint8_t dePin = NO_DE_PIN);
     #ifdef __AVR__
     ModbusRTUSlave(SoftwareSerial& serial, uint8_t dePin = NO_DE_PIN);


### PR DESCRIPTION
Hi, I propose a small change that allows the use of STM32 in USB CDC mode. In this mode, **Serial** inherits from:
```
class USBSerial : public Stream
```
As a result, ModbusRTUSlave cannot be instantiated with the existing constructors.
I'm proposing to add a general **ModbusRTUSlave(Stream& stream...)** constructor.