### PR TITLE
poll() now a bool, true when request occurred

### DIFF
--- a/src/ModbusRTUSlave.cpp
+++ b/src/ModbusRTUSlave.cpp
@@ -95,9 +95,12 @@ void ModbusRTUSlave::begin(uint8_t id, unsigned long baud, uint32_t config) {
 }
 #endif
 
-void ModbusRTUSlave::poll() {
+bool ModbusRTUSlave::poll() {
+  static bool requestOccurred = false; //one-time declaration
+  requestOccurred = false; //assume no request at first
   if (_serial->available()) {
     if (_readRequest()) {
+      requestOccurred = true; //mark that request occurred
       switch (_buf[1]) {
         case 1:
           _processReadCoils();
@@ -129,6 +132,7 @@ void ModbusRTUSlave::poll() {
       }
     }
   }
+  return requestOccurred; 
 }
 
 void ModbusRTUSlave::_processReadCoils() {

--- a/src/ModbusRTUSlave.h
+++ b/src/ModbusRTUSlave.h
@@ -33,7 +33,7 @@ class ModbusRTUSlave {
     #else
     void begin(uint8_t id, unsigned long baud, uint32_t config = SERIAL_8N1);
     #endif
-    void poll();
+    bool poll();
 
   private:
     HardwareSerial *_hardwareSerial = 0;


### PR DESCRIPTION
* `ModbusRTUSlave::poll()` is now a bool, and returns the value `true` when an incoming request has occurred, or false otherwise